### PR TITLE
Prevent InventoryPane's onMouseUp override eating the event

### DIFF
--- a/Contents/mods/game-night/42/media/lua/client/gameNight-actionInventory.lua
+++ b/Contents/mods/game-night/42/media/lua/client/gameNight-actionInventory.lua
@@ -19,9 +19,6 @@ end
 
 local ISInventoryPane_onMouseUp = ISInventoryPane.onMouseUp
 function ISInventoryPane:onMouseUp(x, y)
-    local result = ISInventoryPane_onMouseUp(self, x, y)
-    if not result or not self:getIsVisible() then return result end
-
     local draggingOld = ISMouseDrag.dragging
     local draggingFocusOld = ISMouseDrag.draggingFocus
     local selectedOld = self.selected
@@ -31,6 +28,8 @@ function ISInventoryPane:onMouseUp(x, y)
     local noSpecialKeys = (not isShiftKeyDown() and not isCtrlKeyDown())
     if (noSpecialKeys and x >= self.column2 and x == self.downX and y == self.downY) and self.mouseOverOption ~= 0 and self.items[self.mouseOverOption] ~= nil then busy = true end
 
+    local result = ISInventoryPane_onMouseUp(self, x, y)
+    if not result or not self:getIsVisible() then return result end
     if busy or (not noSpecialKeys) then return end
 
     self.selected = selectedOld

--- a/Contents/mods/game-night/42/media/lua/client/gameNight-actionInventory.lua
+++ b/Contents/mods/game-night/42/media/lua/client/gameNight-actionInventory.lua
@@ -19,7 +19,8 @@ end
 
 local ISInventoryPane_onMouseUp = ISInventoryPane.onMouseUp
 function ISInventoryPane:onMouseUp(x, y)
-    if not self:getIsVisible() then return end
+    local result = ISInventoryPane_onMouseUp(self, x, y)
+    if not result or not self:getIsVisible() then return result end
 
     local draggingOld = ISMouseDrag.dragging
     local draggingFocusOld = ISMouseDrag.draggingFocus
@@ -30,8 +31,6 @@ function ISInventoryPane:onMouseUp(x, y)
     local noSpecialKeys = (not isShiftKeyDown() and not isCtrlKeyDown())
     if (noSpecialKeys and x >= self.column2 and x == self.downX and y == self.downY) and self.mouseOverOption ~= 0 and self.items[self.mouseOverOption] ~= nil then busy = true end
 
-    local result = ISInventoryPane_onMouseUp(self, x, y)
-    if not result then return end
     if busy or (not noSpecialKeys) then return end
 
     self.selected = selectedOld


### PR DESCRIPTION
Fixes #50 

Reason to move vanilla call at the beginning: no mod should eat the events unless it explicitly takes control over an element. `onMouseUp` has been called in the first place, so it's safe to forward the event.

Cheers!